### PR TITLE
Avoids warning "Unhandled promise rejections."

### DIFF
--- a/gpioemitter.js
+++ b/gpioemitter.js
@@ -12,9 +12,9 @@ class GPIOEventEmitter extends EventEmitter {
 			this.emit(type, { type: type, key: name });
 		};
 		this.watchers = [];
-		this.watchers.push(this.watchInterrupt(0, interruptHandler)); // F1
-		this.watchers.push(this.watchInterrupt(2, interruptHandler)); // F2
-		this.watchers.push(this.watchInterrupt(3, interruptHandler)); // F3
+		this.watchers.push(this.watchInterrupt(0, interruptHandler).catch((err) => console.error(err.message))); // F1
+		this.watchers.push(this.watchInterrupt(2, interruptHandler).catch((err) => console.error(err.message))); // F2
+		this.watchers.push(this.watchInterrupt(3, interruptHandler).catch((err) => console.error(err.message))); // F3
 	}
 
 	createEventQueue(events) {
@@ -47,15 +47,12 @@ class GPIOEventEmitter extends EventEmitter {
 	}
 
 	async watchInterrupt(pin, func) {
-		try {
-			await fs.writeFile(`/sys/class/gpio/export`, `${pin}`);
-		} catch (e) {
-			if (e.code === 'EBUSY') {
-				// ignore
-			} else {
+		await fs.writeFile(`/sys/class/gpio/export`, `${pin}`).catch((e) => {
+			if(e.code !== 'EBUSY') {
 				throw e;
 			}
-		}
+		});
+
 		await fs.writeFile(`/sys/class/gpio/gpio${pin}/direction`, 'in');
 		await fs.writeFile(`/sys/class/gpio/gpio${pin}/edge`, 'both'); // falling raising both
 		const fh = await fs.open(`/sys/class/gpio/gpio${pin}/value`, 'r');

--- a/index.js
+++ b/index.js
@@ -147,11 +147,11 @@ function convertToBinary(ctx, x, y, w, h) {
 }
 
 async function loadImage(path) {
-	return await new Promise( async (resolve, reject) => {
+	return new Promise( async (resolve, reject) => {
 		const img = new Canvas.Image();
 		img.onload = () => { resolve(img) };
 		img.onerror = reject;
-		img.src = await fs.readFile(path, null);
+		img.src = await fs.readFile(path, null).catch((err) => reject(err));
 	});
 }
 
@@ -186,10 +186,12 @@ async function loadImage(path) {
 
 		screen.clear();
 		font.drawText(ctx, "init", 65, lineHeight*1-2);
-		const img = await loadImage("./foo.jpg");
-		ctx.drawImage(img, 0, 0, 64, 64);
-		const id = convertToBinary(ctx, 0, 0, 64, 64);
-		ctx.putImageData(id, 0, 0);
+		loadImage("./foo.jpg").then((img) => {
+			ctx.drawImage(img, 0, 0, 64, 64);
+			const id = convertToBinary(ctx, 0, 0, 64, 64);
+			ctx.putImageData(id, 0, 0);
+			return Promise.resolve();
+		}).catch((err) => console.error(err.message));
 
 		setInterval( () => {
 			const now = new Date();


### PR DESCRIPTION
次のPromiseの中でthrowされたエラーをハンドルした

- sysfsに書き込めない場合
- foo.jpgが存在しない場合

```
(node:1) UnhandledPromiseRejectionWarning: Error: EROFS: read-only file system, open '/sys/class/gpio/export'
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:1) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:1) UnhandledPromiseRejectionWarning: Error: EROFS: read-only file system, open '/sys/class/gpio/export'
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:1) UnhandledPromiseRejectionWarning: Error: EROFS: read-only file system, open '/sys/class/gpio/export'
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
clear
load
(node:1) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open './foo.jpg'
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
```